### PR TITLE
Attempt at finding discrepancy between main and adapt-for-rebar3 (no -otp-)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,42 +1,18 @@
 name: Test
 
 on:
-  push: {branches: main}
-  pull_request: {branches: main}
-  repository_dispatch:
-  workflow_dispatch:
+  pull_request: {branches: '*'}
 
 jobs:
-  unit_test:
-    runs-on: ubuntu-latest
-    name: Unit tests
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with: {node-version: '12'}
-      - run: npm ci
-      - run: npm test
-
   integration_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     name: OTP ${{matrix.pair.otp-version}} / Elixir ${{matrix.pair.elixir-version}}
     strategy:
       matrix:
         pair:
           # Full Versions
-          - otp-version: '22.0'
-            elixir-version: '1.9.1'
-          # Semver ranges
-          - otp-version: '21.x'
-            elixir-version: '<1.9.1'
-          # Branches
-          - otp-version: '22.0'
-            elixir-version: master
-          - otp-version: 'master'
-            elixir-version: '1.11.3'
-          # Pre-releases
-          - otp-version: '23.0'
-            elixir-version: '1.11.0-rc.0'
+          - otp-version: '19.3'
+            elixir-version: '1.2.6'
     steps:
       - uses: actions/checkout@v2
       - name: Use erlef/setup-elixir

--- a/dist/.github/workflows/test.yml
+++ b/dist/.github/workflows/test.yml
@@ -1,42 +1,18 @@
 name: Test
 
 on:
-  push: {branches: main}
-  pull_request: {branches: main}
-  repository_dispatch:
-  workflow_dispatch:
+  pull_request: {branches: '*'}
 
 jobs:
-  unit_test:
-    runs-on: ubuntu-latest
-    name: Unit tests
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with: {node-version: '12'}
-      - run: npm ci
-      - run: npm test
-
   integration_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     name: OTP ${{matrix.pair.otp-version}} / Elixir ${{matrix.pair.elixir-version}}
     strategy:
       matrix:
         pair:
           # Full Versions
-          - otp-version: '22.0'
-            elixir-version: '1.9.1'
-          # Semver ranges
-          - otp-version: '21.x'
-            elixir-version: '<1.9.1'
-          # Branches
-          - otp-version: '22.0'
-            elixir-version: master
-          - otp-version: 'master'
-            elixir-version: '1.11.3'
-          # Pre-releases
-          - otp-version: '23.0'
-            elixir-version: '1.11.0-rc.0'
+          - otp-version: '19.3'
+            elixir-version: '1.2.6'
     steps:
       - uses: actions/checkout@v2
       - name: Use erlef/setup-elixir

--- a/dist/install-elixir
+++ b/dist/install-elixir
@@ -8,3 +8,7 @@ wget -q https://repo.hex.pm/builds/elixir/${1}${2}.zip
 unzip -d .setup-elixir/elixir ${1}${2}.zip
 rm ${1}${2}.zip
 echo "$(pwd)/.setup-elixir/elixir/bin" >> $GITHUB_PATH
+echo "Erlang/OTP location: $(which erl)"
+echo "Erlang/OTP version: $(which erl) -version"
+echo "Installed Elixir version follows"
+.setup-elixir/elixir/bin/iex -v

--- a/src/install-elixir
+++ b/src/install-elixir
@@ -8,3 +8,7 @@ wget -q https://repo.hex.pm/builds/elixir/${1}${2}.zip
 unzip -d .setup-elixir/elixir ${1}${2}.zip
 rm ${1}${2}.zip
 echo "$(pwd)/.setup-elixir/elixir/bin" >> $GITHUB_PATH
+echo "Erlang/OTP location: $(which erl)"
+echo "Erlang/OTP version: $(which erl) -version"
+echo "Installed Elixir version follows"
+.setup-elixir/elixir/bin/iex -v


### PR DESCRIPTION
⚠️ this is not a mergeable. This is to fundament an ongoing topic discussion.

@ericmj: I created this very small PoC to see try and find the discrepancy from `main` and #9.

I target (as per our discussion) `ubuntu-16.04`, Elixir 1.2.6 and Erlang/OTP 19.3.6.

I also try to output the actual installed versions of Erlang and Elixir.